### PR TITLE
[Sikkerhet] Oppdaterer beskrivelse.yaml fra versjon 1.0 til 3.0 og oppretter catalog-info.yaml

### DIFF
--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,2 +1,5 @@
-version: 1.0
-organisasjon: Land
+version: 3.0
+organization: Land
+product: GeoNorge
+repo_types: [Documentation]
+platforms: []

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,37 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "docs.geonorge.no"
+  tags:
+  - "public"
+spec:
+  type: "documentation"
+  lifecycle: "production"
+  owner: "land"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Group"
+metadata:
+  name: "security_champion_docs.geonorge.no"
+  title: "Security Champion docs.geonorge.no"
+spec:
+  type: "security_champion"
+  parent: "land_security_champions"
+  members:
+  - "henrik716"
+  children:
+  - "resource:docs.geonorge.no"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
+metadata:
+  name: "docs.geonorge.no"
+  links:
+  - url: "https://github.com/kartverket/docs.geonorge.no"
+    title: "docs.geonorge.no på GitHub"
+spec:
+  type: "repo"
+  owner: "security_champion_docs.geonorge.no"
+  dependencyOf:
+  - "component:docs.geonorge.no"


### PR DESCRIPTION
Videre oppdaterer denne PRen catalog-info.yaml for å gi entiteter til Backstage.

Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.