### PR TITLE
[Sikkerhet] Oppdaterer med ny catalog-info.yaml og engelske filnavn

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/.sikkerhet/ @henrik716
+/.security/ @henrik716

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,4 +1,3 @@
-version: 3.0
 organization: Land
 product: GeoNorge
 repo_types: [Documentation]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,29 +9,3 @@ spec:
   type: "documentation"
   lifecycle: "production"
   owner: "land"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Group"
-metadata:
-  name: "security_champion_docs.geonorge.no"
-  title: "Security Champion docs.geonorge.no"
-spec:
-  type: "security_champion"
-  parent: "land_security_champions"
-  members:
-  - "henrik716"
-  children:
-  - "resource:docs.geonorge.no"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "docs.geonorge.no"
-  links:
-  - url: "https://github.com/kartverket/docs.geonorge.no"
-    title: "docs.geonorge.no på GitHub"
-spec:
-  type: "repo"
-  owner: "security_champion_docs.geonorge.no"
-  dependencyOf:
-  - "component:docs.geonorge.no"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage. Vi fjerner nå resource og sec. champ hierarkiet. Videre dropper vi å ha versionsnummer i description.yaml